### PR TITLE
Minor tweaks from my lessons learned

### DIFF
--- a/webusb-serial/application.js
+++ b/webusb-serial/application.js
@@ -1,6 +1,21 @@
 (function() {
   'use strict';
 
+  if (!('usb' in navigator)) {
+    window.addEventListener('DOMContentLoaded', () => {
+      const warning = document.createElement('div');
+      warning.style.background = '#ffdddd';
+      warning.style.color = '#a00';
+      warning.style.padding = '1em';
+      warning.style.margin = '1em 0';
+      warning.style.border = '1px solid #a00';
+      warning.style.fontWeight = 'bold';
+      warning.textContent = 'This browser does not support WebUSB. Use a Chromium-based browser such as Chrome, Edge, or Opera.';
+      document.body.insertBefore(warning, document.body.firstChild);
+    });
+    return;
+  }
+
   document.addEventListener('DOMContentLoaded', event => {
     let connectButton = document.querySelector("#connect");
     let statusDisplay = document.querySelector('#status');
@@ -47,6 +62,12 @@
         };
         port.onReceiveError = error => {
           console.error(error);
+          if (error && (error.name === 'NetworkError' || error.message === 'NetworkError') && port) {
+            port.disconnect();
+            connectButton.textContent = 'Connect';
+            statusDisplay.textContent = 'Lost connection with device';
+            port = null;
+          }
         };
       }, error => {
         statusDisplay.textContent = error;
@@ -69,6 +90,8 @@
       }
     });
 
+    // Try to connect to first device when page is loaded
+    // Note: this will only succeed when the page is running on localhost (see note in serial.js)
     serial.getPorts().then(ports => {
       if (ports.length === 0) {
         statusDisplay.textContent = 'No device found.';

--- a/webusb-serial/application.js
+++ b/webusb-serial/application.js
@@ -62,7 +62,7 @@
         };
         port.onReceiveError = error => {
           console.error(error);
-          if (error && error.name === 'NetworkError' && port) {
+          if (port) {
             port.disconnect();
             connectButton.textContent = 'Connect';
             statusDisplay.textContent = 'Lost connection with device';

--- a/webusb-serial/application.js
+++ b/webusb-serial/application.js
@@ -62,7 +62,7 @@
         };
         port.onReceiveError = error => {
           console.error(error);
-          if (error && (error.name === 'NetworkError' || error.message === 'NetworkError') && port) {
+          if (error && error.name === 'NetworkError' && port) {
             port.disconnect();
             connectButton.textContent = 'Connect';
             statusDisplay.textContent = 'Lost connection with device';

--- a/webusb-serial/application.js
+++ b/webusb-serial/application.js
@@ -80,9 +80,7 @@
         };
         port.onReceiveError = error => {
           console.error(error);
-          if (port) {
-            disconnect('Lost connection with device');
-          }
+          disconnect('Lost connection with device');
         };
       }, error => {
         statusDisplay.textContent = error;

--- a/webusb-serial/application.js
+++ b/webusb-serial/application.js
@@ -20,6 +20,7 @@
     let connectButton = document.querySelector("#connect");
     let statusDisplay = document.querySelector('#status');
     let port;
+    let disconnecting = false;
 
     function addLine(linesId, text) {
       var senderLine = document.createElement("div");
@@ -46,6 +47,23 @@
       }
     }
 
+    function disconnect(reason = '') {
+      if (!port || disconnecting) {
+        // Nothing else to do
+        return;
+      }
+
+      statusDisplay.textContent = 'Disconnecting...';
+      disconnecting = true;
+
+      port.disconnect().finally(() => {
+        connectButton.textContent = 'Connect';
+        statusDisplay.textContent = reason;
+        port = null;
+        disconnecting = false;
+      });
+    }
+
     function connect() {
       port.connect().then(() => {
         statusDisplay.textContent = '';
@@ -63,10 +81,7 @@
         port.onReceiveError = error => {
           console.error(error);
           if (port) {
-            port.disconnect();
-            connectButton.textContent = 'Connect';
-            statusDisplay.textContent = 'Lost connection with device';
-            port = null;
+            disconnect('Lost connection with device');
           }
         };
       }, error => {
@@ -76,10 +91,7 @@
 
     connectButton.addEventListener('click', function() {
       if (port) {
-        port.disconnect();
-        connectButton.textContent = 'Connect';
-        statusDisplay.textContent = '';
-        port = null;
+        disconnect();
       } else {
         serial.requestPort().then(selectedPort => {
           port = selectedPort;

--- a/webusb-serial/serial.js
+++ b/webusb-serial/serial.js
@@ -89,8 +89,12 @@ var serial = {};
             'request': 0x22,
             'value': 0x00,
             'index': this.interfaceNumber})
-        .finally(() => this.device_.reset())
-        .finally(() => this.device_.close());
+        .finally(() => {
+          return this.device_.reset().catch(() => {});
+        })
+        .finally(() => {
+          return this.device_.close().catch(() => {});
+        });
   };
 
   serial.Port.prototype.send = function(data) {

--- a/webusb-serial/serial.js
+++ b/webusb-serial/serial.js
@@ -36,7 +36,9 @@ var serial = {};
   serial.Port.prototype.connect = function() {
     let readLoop = () => {
       this.device_.transferIn(this.endpointIn, 64).then(result => {
-        this.onReceive(result.data);
+        if (result.data && result.data.byteLength > 0) {
+          this.onReceive(result.data);
+        }
         readLoop();
       }, error => {
         this.onReceiveError(error);

--- a/webusb-serial/serial.js
+++ b/webusb-serial/serial.js
@@ -89,12 +89,7 @@ var serial = {};
             'request': 0x22,
             'value': 0x00,
             'index': this.interfaceNumber})
-        .finally(() => {
-          return this.device_.reset().catch(() => {});
-        })
-        .finally(() => {
-          return this.device_.close().catch(() => {});
-        });
+        .finally(() => this.device_.reset().finally(() => this.device_.close()));
   };
 
   serial.Port.prototype.send = function(data) {

--- a/webusb-serial/serial.js
+++ b/webusb-serial/serial.js
@@ -87,7 +87,8 @@ var serial = {};
             'request': 0x22,
             'value': 0x00,
             'index': this.interfaceNumber})
-        .then(() => this.device_.close());
+        .finally(() => this.device_.reset())
+        .finally(() => this.device_.close());
   };
 
   serial.Port.prototype.send = function(data) {

--- a/webusb-serial/serial.js
+++ b/webusb-serial/serial.js
@@ -3,12 +3,16 @@ var serial = {};
 (function() {
   'use strict';
 
+  // Note: This will only return devices that have been granted permission to by the browser.
+  //       Permission is normally only granted when page is running on localhost or after device
+  //       has been selected on navigator.usb.requestDevice() (in serial.requestPort() below).
   serial.getPorts = function() {
     return navigator.usb.getDevices().then(devices => {
       return devices.map(device => new serial.Port(device));
     });
   };
 
+  // Note: The user has to interact with the page or a UI element in order for this feature to work.
   serial.requestPort = function() {
     const filters = [
       { 'vendorId': 0xcafe }, // TinyUSB


### PR DESCRIPTION
This is a great introduction into WebUSB. I found it very useful with getting it integrated in my project. The goal of these updates is to make it easier for people to get up to speed.

- Added support detection: warning banner will display if these features are not supported by the browser. It seems like only Chromium-based browsers support this feature at the moment, so the text suggest a few options.
- Don't try calling onReceive() unless at least 1 byte is in data (this happens on Linux systems when a stall occurs after physical disconnect)
- Automatically disconnect when device is removed
- Always call `this.device_.reset()` then `this.device_.close()` on disconnect: I found that calling `reset()` is imperative to be able to reconnect when running on a Linux system. For Windows, calling `close()` is more important, but calling `reset()` then `close()` on a Linux system doesn't always work. Doing both in finally blocks works for either system. 🥴 
    - Note that there is a known bug with reset() on MacOS which doesn't seem to be resolved yet: https://issues.chromium.org/issues/40755412
- Added some comments which help explain when certain features are available